### PR TITLE
libgd 2.3.3

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -x
 
+# resolving test issues, see: https://github.com/libgd/libgd/issues/763#issuecomment-918049103
 export TMPDIR=$SRC_DIR/temp_files
 mkdir -p $TMPDIR
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -15,6 +15,7 @@ fi
 find ${PREFIX} -name '*.la' -delete
 autoreconf -vfi
 ./configure --prefix=$PREFIX \
+            --enable-gd-formats \
             --without-xpm \
             --without-x \
             --disable-werror \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -16,7 +16,6 @@ fi
 find ${PREFIX} -name '*.la' -delete
 autoreconf -vfi
 ./configure --prefix=$PREFIX \
-            --enable-gd-formats \
             --without-xpm \
             --without-x \
             --disable-werror \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -x
 
+export TMPDIR=$SRC_DIR/temp_files
+mkdir -p $TMPDIR
+
 if [[ ${target_platform} == linux-ppc64le ]]; then
   # https://github.com/libgd/libgd/issues/278
   export CFLAGS="$CFLAGS -ffp-contract=off"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   skip: True  # [win or s390x]
-  number: 3
+  number: 0
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=libgd
     - {{ pin_subpackage('libgd', max_pin='x.x') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,6 @@ requirements:
     - libpng
     - libtiff
     - libwebp-base
-    - zlib
   run:
     - expat
     - fontconfig
@@ -54,7 +53,6 @@ requirements:
     - libiconv  # [osx]
     - libpng
     - libtiff
-    - zlib
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,8 @@ requirements:
     - gettext
     - pkg-config
     - make
+    - patch     # [unix]
+    - m2-patch  # [win]
   host:
     - expat
     - fontconfig

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - patches/linux-fontconfig-basic.patch
 
 build:
-  skip: True  # [win]
+  skip: True  # [win or s390x]
   number: 3
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=libgd
@@ -43,7 +43,7 @@ requirements:
     - libiconv  # [osx]
     - libpng
     - libtiff
-    - libwebp
+    - libwebp-base
     - zlib
   run:
     - expat
@@ -54,7 +54,6 @@ requirements:
     - libiconv  # [osx]
     - libpng
     - libtiff
-    - libwebp
     - zlib
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2.3.2" %}
-{% set sha256 = "ee0c74852c102140fc590541950127b63a3c6fa4592305c16738d23ed65f8ac3" %}
+{% set version = "2.3.3" %}
+{% set sha256 = "dd3f1f0bb016edcc0b2d082e8229c822ad1d02223511997c80461481759b1ed2" %}
 
 package:
   name: libgd

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,6 +66,7 @@ about:
     license_family: BSD
     license_file: COPYING
     dev_url: https://github.com/libgd/libgd
+    doc_url: https://libgd.github.io/pages/docs.html
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Update libgd to 2.3.3

Regarding `zlib` removal:
>zlib.h is only used in the legacy gd image format GD2, which is no longer built by default in v2.3.0 of libgd. There is also mention that these legacy formats should only be used for development and testing purposes.
>
>See: https://libgd.github.io/manuals/2.3.0/files/gd_gd2-c.html

The other option would be to configure with `--enable-gd-formats` and include `zlib`. I am open to either approach.