### PR TITLE
libgd 2.3.3: Rebuild with libtiff 4.7.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -5,3 +5,4 @@ build_parameters:
 
 channels:
   - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/9f246b8
+  - https://staging.continuum.io/prefect/fs/libwebp-feedstock/pr9/8ca27b2

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,7 +2,3 @@
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
-
-channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/34f8d4b
-  - https://staging.continuum.io/prefect/fs/libwebp-feedstock/pr9/53e70a8

--- a/abs.yaml
+++ b/abs.yaml
@@ -4,6 +4,5 @@ build_parameters:
   - "--error-overlinking"
 
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/475b812
-  - https://staging.continuum.io/prefect/fs/libwebp-feedstock/pr9/0896de1
-
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/34f8d4b
+  - https://staging.continuum.io/prefect/fs/libwebp-feedstock/pr9/53e70a8

--- a/abs.yaml
+++ b/abs.yaml
@@ -4,5 +4,6 @@ build_parameters:
   - "--error-overlinking"
 
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe
-  - https://staging.continuum.io/prefect/fs/libwebp-feedstock/pr9/66bba6f
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/475b812
+  - https://staging.continuum.io/prefect/fs/libwebp-feedstock/pr9/0896de1
+

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,3 +3,5 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
 
+channels:
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/9f246b8

--- a/abs.yaml
+++ b/abs.yaml
@@ -4,5 +4,5 @@ build_parameters:
   - "--error-overlinking"
 
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/9f246b8
-  - https://staging.continuum.io/prefect/fs/libwebp-feedstock/pr9/8ca27b2
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe
+  - https://staging.continuum.io/prefect/fs/libwebp-feedstock/pr9/66bba6f

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ source:
 
 build:
   number: 4
+  skip: true  # [s390x]
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=libgd
     - {{ pin_subpackage('libgd', max_pin='x.x') }}
@@ -50,7 +51,7 @@ requirements:
     - fontconfig
     - freetype
     - jpeg
-    - libiconv >=1.16,<2.0a0     # [osx]
+    - libiconv  # [osx]
     - libpng
     - libtiff
     - libwebp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - m2-sed        # [win]
     - m2-gawk       # [win]
   host:
-    - expat 2.6.4
+    - expat {{ expat }}
     - fontconfig {{ fontconfig }}
     - freetype {{ freetype }}
     - jpeg {{ jpeg }}
@@ -46,17 +46,16 @@ requirements:
     - libwebp-base {{ libwebp }}
     - zlib {{ zlib }}
   run:
-    - expat >=2.4.9,<3.0a0
-    - fontconfig >=2.14.1,<3.0a0
-    - freetype >=2.10.4,<3.0a0
-    - jpeg >=9e,<10a
+    - expat
+    - fontconfig
+    - freetype
+    - jpeg
     - libiconv >=1.16,<2.0a0     # [osx]
-    - libpng >=1.6.37,<1.7.0a0
-    - libtiff >=4.1.0,<5.0a0  # [not ((osx and arm64) or (linux and aarch64))]
-    - libtiff >=4.2.0,<5.0a0  # [(osx and arm64) or (linux and aarch64)]
-    - libwebp >=1.2.0,<1.3.0a0
-    - libwebp-base >=1.2.0,<1.3.0a0
-    - zlib >=1.2.13,<1.3.0a0
+    - libpng
+    - libtiff
+    - libwebp
+    - libwebp-base
+    - zlib
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ requirements:
     - jpeg {{ jpeg }}
     - libiconv 1.16     # [osx]
     - libpng {{ libpng }}
-    - libtiff 4.7.0
+    - libtiff {{ libtiff }}
     - libwebp-base {{ libwebp }}
     - zlib {{ zlib }}
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - patches/linux-fontconfig-basic.patch
 
 build:
-  number: 3
+  number: 4
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=libgd
     - {{ pin_subpackage('libgd', max_pin='x.x') }}
@@ -36,17 +36,15 @@ requirements:
     - m2-sed        # [win]
     - m2-gawk       # [win]
   host:
-    - expat 2.4.9
-    - fontconfig 2.14
-    - freetype 2.10
-    - jpeg 9e
+    - expat 2.6.4
+    - fontconfig {{ fontconfig }}
+    - freetype {{ freetype }}
+    - jpeg {{ jpeg }}
     - libiconv 1.16     # [osx]
-    - libpng 1.6.*
-    - libtiff 4.1.*  # [not ((osx and arm64) or (linux and aarch64))]
-    - libtiff 4.2.*  # [(osx and arm64) or (linux and aarch64)]
-    - libwebp 1.2
-    - libwebp-base
-    - zlib 1.2.*
+    - libpng {{ libpng }}
+    - libtiff 4.7.0
+    - libwebp {{ libwebp }}
+    - zlib {{ zlib }}
   run:
     - expat >=2.4.9,<3.0a0
     - fontconfig >=2.14.1,<3.0a0
@@ -57,7 +55,6 @@ requirements:
     - libtiff >=4.1.0,<5.0a0  # [not ((osx and arm64) or (linux and aarch64))]
     - libtiff >=4.2.0,<5.0a0  # [(osx and arm64) or (linux and aarch64)]
     - libwebp >=1.2.0,<1.3.0a0
-    - libwebp-base
     - zlib >=1.2.13,<1.3.0a0
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,6 @@ source:
 
 build:
   number: 4
-  skip: true  # [s390x]
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=libgd
     - {{ pin_subpackage('libgd', max_pin='x.x') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,6 @@ requirements:
     - libiconv 1.16     # [osx]
     - libpng {{ libpng }}
     - libtiff 4.7.0
-    - libwebp {{ libwebp }}
     - libwebp-base {{ libwebp }}
     - zlib {{ zlib }}
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,7 @@ requirements:
     - libpng {{ libpng }}
     - libtiff 4.7.0
     - libwebp {{ libwebp }}
+    - libwebp-base {{ libwebp }}
     - zlib {{ zlib }}
   run:
     - expat >=2.4.9,<3.0a0
@@ -55,6 +56,7 @@ requirements:
     - libtiff >=4.1.0,<5.0a0  # [not ((osx and arm64) or (linux and aarch64))]
     - libtiff >=4.2.0,<5.0a0  # [(osx and arm64) or (linux and aarch64)]
     - libwebp >=1.2.0,<1.3.0a0
+    - libwebp-base >=1.2.0,<1.3.0a0
     - zlib >=1.2.13,<1.3.0a0
 
 test:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-7590](https://anaconda.atlassian.net/browse/PKG-7590) 
- [Upstream repository](https://github.com/libgd/libgd/tree/gd-2.3.3)

### Explanation of changes:

- Bump build number to 4
- Pin host deps
- Remove pins at runtime (rely on run_exports)


[PKG-7590]: https://anaconda.atlassian.net/browse/PKG-7590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ