### PR TITLE
Rebuild against libjpeg-turbo

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - patches/linux-fontconfig-basic.patch
 
 build:
-  number: 5
+  number: 6
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=libgd
     - {{ pin_subpackage('libgd', max_pin='x.x') }}
@@ -37,8 +37,8 @@ requirements:
     - libexpat {{ expat }}
     - fontconfig {{ fontconfig }}
     - freetype {{ freetype }}
-    - jpeg {{ jpeg }}
-    - libiconv 1.16     # [osx]
+    - libjpeg-turbo {{ libjpeg_turbo }}
+    - libiconv {{ libiconv }}     # [osx]
     - libpng {{ libpng }}
     - libtiff {{ libtiff }}
     - libwebp-base {{ libwebp }}


### PR DESCRIPTION
libgd 2.3.3

**Destination channel:**  defaults

### Links

- [PKG-13238](https://anaconda.atlassian.net/browse/PKG-13238) 
- [Upstream repository](https://github.com/libgd/libgd/tree/gd-2.3.3)

### Explanation of changes:
- Rebuild against libjpeg-turbo


[PKG-13238]: https://anaconda.atlassian.net/browse/PKG-13238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ